### PR TITLE
document how to make concourse lite disk space bigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # Concourse Lite
+
+
+How to make the worker disk store bigger (200 GB) on an AMI after it's been spun up:
+
+```
+sudo apt-get update && sudo apt-get install btrfs-tools -y
+sudo /var/vcap/packages/baggageclaim/bin/fs_mounter -remove -diskImage /var/vcap/data/baggageclaim/volumes.img -mountPath /var/vcap/data/baggageclaim/volumes
+sudo /var/vcap/packages/baggageclaim/bin/fs_mounter  -diskImage /var/vcap/data/baggageclaim/volumes.img -mountPath /var/vcap/data/baggageclaim/volumes -sizeInMegabytes 200000 1>>/var/vcap/sys/log/baggageclaim/fs_mounter.stdout.log 2>>/var/vcap/sys/log/baggageclaim/fs_mounter.stderr.log

--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ How to make the worker disk store bigger (200 GB) on an AMI after it's been spun
 
 ```
 sudo apt-get update && sudo apt-get install btrfs-tools -y
-sudo /var/vcap/packages/baggageclaim/bin/fs_mounter -remove -diskImage /var/vcap/data/baggageclaim/volumes.img -mountPath /var/vcap/data/baggageclaim/volumes
-sudo /var/vcap/packages/baggageclaim/bin/fs_mounter -diskImage /var/vcap/data/baggageclaim/volumes.img -mountPath /var/vcap/data/baggageclaim/volumes -sizeInMegabytes 200000
+sudo /var/vcap/packages/baggageclaim/bin/fs_mounter --remove --disk-image=/var/vcap/data/baggageclaim/volumes.img --mount-path /var/vcap/data/baggageclaim/volumes
+sudo /var/vcap/packages/baggageclaim/bin/fs_mounter --disk-image=/var/vcap/data/baggageclaim/volumes.img --mount-path=/var/vcap/data/baggageclaim/volumes --size-in-megabytes=200000
 sudo mkdir /var/vcap/data/baggageclaim/volumes/{live,dead,init}

--- a/README.md
+++ b/README.md
@@ -6,4 +6,5 @@ How to make the worker disk store bigger (200 GB) on an AMI after it's been spun
 ```
 sudo apt-get update && sudo apt-get install btrfs-tools -y
 sudo /var/vcap/packages/baggageclaim/bin/fs_mounter -remove -diskImage /var/vcap/data/baggageclaim/volumes.img -mountPath /var/vcap/data/baggageclaim/volumes
-sudo /var/vcap/packages/baggageclaim/bin/fs_mounter  -diskImage /var/vcap/data/baggageclaim/volumes.img -mountPath /var/vcap/data/baggageclaim/volumes -sizeInMegabytes 200000 1>>/var/vcap/sys/log/baggageclaim/fs_mounter.stdout.log 2>>/var/vcap/sys/log/baggageclaim/fs_mounter.stderr.log
+sudo /var/vcap/packages/baggageclaim/bin/fs_mounter  -diskImage /var/vcap/data/baggageclaim/volumes.img -mountPath /var/vcap/data/baggageclaim/volumes -sizeInMegabytes 200000
+sudo mkdir /var/vcap/data/baggageclaim/volumes/{live,dead,init}

--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@ How to make the worker disk store bigger (200 GB) on an AMI after it's been spun
 ```
 sudo apt-get update && sudo apt-get install btrfs-tools -y
 sudo /var/vcap/packages/baggageclaim/bin/fs_mounter -remove -diskImage /var/vcap/data/baggageclaim/volumes.img -mountPath /var/vcap/data/baggageclaim/volumes
-sudo /var/vcap/packages/baggageclaim/bin/fs_mounter  -diskImage /var/vcap/data/baggageclaim/volumes.img -mountPath /var/vcap/data/baggageclaim/volumes -sizeInMegabytes 200000
+sudo /var/vcap/packages/baggageclaim/bin/fs_mounter -diskImage /var/vcap/data/baggageclaim/volumes.img -mountPath /var/vcap/data/baggageclaim/volumes -sizeInMegabytes 200000
 sudo mkdir /var/vcap/data/baggageclaim/volumes/{live,dead,init}


### PR DESCRIPTION
I don't necessarily want this merged, but it would nice to either document how to make the volume store bigger on the concourse lite AMIs, or make it bigger than 8 GB by default.
