### PR TITLE
Update the vmware build process

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -1,0 +1,21 @@
+## How to build a fresh box file
+
+### Virtualbox
+
+The Concourse team provides a prebuilt Virtualbox based box already - just use that.
+
+### VMware
+
+1. Be sure you have a copy of [Packer](https://www.packer.io) locally installed. Generally, for a Mac user, this is as simple as `brew install packer`.
+
+2. Get a copy of the concourse executable from the [concourse.ci website](https://concourse.ci/downloads.html) specific to your target environment, typically Linux. Download and drop it in the root folder. This will get copied directly into the new .box file.
+
+3.  Build the .box file for VMware Fusion/Desktop by passing it the version# like so:
+```
+./bin/build-vmware "1.3.0"
+```
+When this is done, you'll see a new output folder for the vmware based box, and a shiny new .box file in the root folder.
+
+Note: After doing a `vagrant box add` and then trying to `vagrant up` my box, I had an issue with the HGFS stuff coming up. I ended up following [a KB article on the VMware website](https://kb.vmware.com/selfservice/microsites/search.do?language=en_US&cmd=displayKC&externalId=1022525) to reinstall the Tools, and that fixed things up.
+
+We prob need to fix the VMware Tools install script.

--- a/bin/build-vmware
+++ b/bin/build-vmware
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e -x
+
+CONCOURSE_RELEASE_VERSION=${1}
+
+function usage() {
+  echo "usage: $0 CONCOURSE_RELEASE_VERSION" >&2
+  exit 1
+}
+
+[ -n "$CONCOURSE_RELEASE_VERSION" ] || usage
+
+build_dir=$(cd $(dirname $0)/.. && pwd)
+
+cd ${build_dir}
+
+packer build \
+  -var "version=${CONCOURSE_RELEASE_VERSION}" \
+  ./templates/vmware.json

--- a/templates/vmware.json
+++ b/templates/vmware.json
@@ -46,7 +46,7 @@
 
     "disk_size": 81920,
 
-    "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+    "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
 
     "vmx_data": {
       "memsize": "2048",
@@ -76,18 +76,36 @@
     "type": "shell",
     "inline": "echo 'vagrant' | sudo -S usermod -a -G admin vagrant"
   },{
-    "type": "packer-bosh",
-    "assets_dir": "packer-bosh/assets",
-    "manifest_path": "bosh_lite_manifest.yml",
-    "ssh_password": "vagrant"
+    "type": "file",
+    "source": "concourse_linux_amd64",
+    "destination": "/tmp/concourse"
   },{
     "type": "shell",
     "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -S -E {{ .Path }}",
-    "remote_path": "/opt/bosh-provisioner/packer-shell.sh",
+    "inline": "install /tmp/concourse /usr/local/bin/concourse"
+  },{
+    "type": "file",
+    "source": "upstart/concourse-worker.conf",
+    "destination": "/tmp/concourse-worker.conf"
+  },{
+    "type": "file",
+    "source": "upstart/concourse-web.conf",
+    "destination": "/tmp/concourse-web.conf"
+  },{
+    "type": "shell",
+    "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -S -E {{ .Path }}",
+    "inline": "mv /tmp/concourse-*.conf /etc/init"
+  },{
+    "type": "shell",
+    "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -S -E {{ .Path }}",
     "scripts": [
-      "scripts/add-vcap-to-vagrant.sh",
-      "scripts/set-temp-dir.sh",
-      "scripts/install-cli-tools.sh",
+      "scripts/generate-concourse-keys.sh",
+      "scripts/setup-postgresql.sh"
+    ]
+  },{
+    "type": "shell",
+    "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -S -E {{ .Path }}",
+    "scripts": [
       "scripts/clean-up.sh",
       "scripts/shrink-disk.sh"
     ]
@@ -97,6 +115,6 @@
     "type": "vagrant",
     "keep_input_artifact": true,
     "vagrantfile_template": "templates/vagrant-local.tpl",
-    "output": "bosh-lite-{{ .Provider }}-ubuntu-trusty-{{user `build_number`}}.box"
+    "output": "concourse-{{ .Provider }}-ubuntu-trusty-{{user `build_number`}}.box"
   }]
 }


### PR DESCRIPTION
Tonight, with some good direction from @vito, I was able to successfully update the template used to generate a functioning VMware Fusion box file.

This involved:
- Creating a script to build a vmware box based on the existing virtual box script
- Update the vmware template to match the new "embed" approach taken with the virtualbox template.
- Added a README to the bin folder to help other who want to build a box from scratch. It may or may not make sense to move this to the main README - feedback would be great on where this should go.
