### PR TITLE
Remove hardcoded 192.168.100.4 IP address

### DIFF
--- a/templates/vagrant-local.tpl
+++ b/templates/vagrant-local.tpl
@@ -1,5 +1,5 @@
-VM_MEMORY = ENV.fetch('VM_MEMORY', 6*1024).to_i
-VM_CORES = ENV.fetch('VM_CORES', 4).to_i
+VM_MEMORY = ENV.fetch('VM_MEMORY', 2*1024).to_i
+VM_CORES = ENV.fetch('VM_CORES', 2).to_i
 
 Vagrant.configure('2') do |config|
   config.vm.network :private_network, ip: '192.168.100.4', id: :local

--- a/upstart/concourse-web.conf
+++ b/upstart/concourse-web.conf
@@ -6,7 +6,7 @@ stop on shutdown
 
 exec concourse web \
   --development-mode \
-  --external-url `ifconfig eth0 | grep "inet addr" | cut -d ':' -f 2 | cut -d ' ' -f 1` \
+  --external-url http://`ifconfig eth0 | grep "inet addr" | cut -d ':' -f 2 | cut -d ' ' -f 1`:8080 \
   --session-signing-key /opt/concourse/session_signing_key \
   --tsa-host-key /opt/concourse/host_key \
   --tsa-authorized-keys /opt/concourse/authorized_worker_keys \

--- a/upstart/concourse-web.conf
+++ b/upstart/concourse-web.conf
@@ -6,7 +6,7 @@ stop on shutdown
 
 exec concourse web \
   --development-mode \
-  --external-url http://192.168.100.4:8080 \
+  --external-url `ifconfig eth0 | grep "inet addr" | cut -d ':' -f 2 | cut -d ' ' -f 1` \
   --session-signing-key /opt/concourse/session_signing_key \
   --tsa-host-key /opt/concourse/host_key \
   --tsa-authorized-keys /opt/concourse/authorized_worker_keys \

--- a/upstart/concourse-worker.conf
+++ b/upstart/concourse-worker.conf
@@ -9,6 +9,6 @@ exec concourse worker \
     --tsa-host 127.0.0.1 \
     --tsa-public-key /opt/concourse/host_key.pub \
     --tsa-worker-private-key /opt/concourse/worker_key \
-    --peer-ip 192.168.100.4 \
+    --peer-ip `ifconfig eth0 | grep "inet addr" | cut -d ':' -f 2 | cut -d ' ' -f 1` \
     --bind-ip 0.0.0.0 \
     --baggageclaim-bind-ip 0.0.0.0


### PR DESCRIPTION
I'd like to propose changing the hardcoded 192.168.100.4 address into something that detects the current IP address automatically.

This was my implementation using `ifconfig eth0 | grep "inet addr" | cut -d ':' -f 2 | cut -d ' ' -f 1`.

It properly detects the current `eth0` IP address and places it in the .conf files for the web/worker processes.

I use Vagrant with NAT bridging so this allows the RedirectURI to be formatted properly.
