### PR TITLE
Remove hardcoded 192.168.100.4 IP address

### DIFF
--- a/upstart/concourse-web.conf
+++ b/upstart/concourse-web.conf
@@ -4,10 +4,16 @@ author "Concourse Team"
 start on runlevel [2345]
 stop on shutdown
 
+script
+IPADDR=`ip route get 8.8.8.8 | grep src | head -1 | sed 's/.*src \([^ ]\+\).*/\1/'`
+if [ -z "$IPADDR" ]; then
+        IPADDR=192.168.100.4
+fi
 exec concourse web \
   --development-mode \
-  --external-url http://192.168.100.4:8080 \
+  --external-url http://$IPADDR:8080 \
   --session-signing-key /opt/concourse/session_signing_key \
   --tsa-host-key /opt/concourse/host_key \
   --tsa-authorized-keys /opt/concourse/authorized_worker_keys \
   --postgres-data-source postgres://vagrant:vagrant@127.0.0.1:5432/atc?sslmode=disable
+end script

--- a/upstart/concourse-worker.conf
+++ b/upstart/concourse-worker.conf
@@ -14,7 +14,7 @@ exec concourse worker \
     --tsa-host 127.0.0.1 \
     --tsa-public-key /opt/concourse/host_key.pub \
     --tsa-worker-private-key /opt/concourse/worker_key \
-    --peer-ip 192.168.100.4 \
+    --peer-ip $IPADDR \
     --bind-ip 0.0.0.0 \
     --baggageclaim-bind-ip 0.0.0.0
 end script

--- a/upstart/concourse-worker.conf
+++ b/upstart/concourse-worker.conf
@@ -4,6 +4,11 @@ author "Concourse Team"
 start on runlevel [2345]
 stop on shutdown
 
+script
+IPADDR=`ip route get 8.8.8.8 | grep src | head -1 | sed 's/.*src \([^ ]\+\).*/\1/'`
+if [ -z "$IPADDR" ]; then
+        IPADDR=192.168.100.4
+fi
 exec concourse worker \
     --work-dir /tmp/concourse \
     --tsa-host 127.0.0.1 \
@@ -12,3 +17,4 @@ exec concourse worker \
     --peer-ip 192.168.100.4 \
     --bind-ip 0.0.0.0 \
     --baggageclaim-bind-ip 0.0.0.0
+end script


### PR DESCRIPTION
I'd like to propose changing the hardcoded `192.168.100.4` address into something that detects the current IP address automatically.

This was my implementation using `ifconfig eth0 | grep "inet addr" | cut -d ':' -f 2 | cut -d ' ' -f 1`.

It properly detects the current `eth0` IP address and places it in the .conf files for the web/worker processes.

I use Vagrant with bridging so this allows the RedirectURI to be formatted properly for using OAuth.
