### PR TITLE
Lower VMware box to 2xCPU

### DIFF
--- a/templates/vmware.json
+++ b/templates/vmware.json
@@ -50,7 +50,7 @@
 
     "vmx_data": {
       "memsize": "2048",
-      "numvcpus": "4",
+      "numvcpus": "2",
       "cpuid.coresPerSocket": "1"
     }
   }],


### PR DESCRIPTION
Lowering VMWare box template to 2*vCPU to match the lowered virtualbox specs implemented in #12 .
