### PR TITLE
Don't put it in head, put it in tail!

### DIFF
--- a/scripts/update-resolv.conf.sh
+++ b/scripts/update-resolv.conf.sh
@@ -2,5 +2,5 @@
 
 set -ex
 
-echo 'nameserver 8.8.8.8' >> /etc/resolvconf/resolv.conf.d/head
+echo 'nameserver 8.8.8.8' >> /etc/resolvconf/resolv.conf.d/tail
 resolvconf -u


### PR DESCRIPTION
As mentioned in issue #1 putting Google's DNS in the resolvconf HEAD file breaks internal DNS.

This PR puts it in the tail so that the next build of this box will not break internal DNS.