### PR TITLE
Have concourse worker use any locally configured proxies.

### DIFF
--- a/upstart/concourse-worker.conf
+++ b/upstart/concourse-worker.conf
@@ -4,7 +4,13 @@ author "Concourse Team"
 start on runlevel [2345]
 stop on shutdown
 
-exec concourse worker \
+script
+  exec /bin/bash << 'EOT'
+  eval $(cat /etc/environment | sed 's/^/export /')
+  concourse worker \
+    --http-proxy=$http_proxy \
+    --https-proxy=$https_proxy \
+    --no-proxy=$no_proxy \
     --work-dir /tmp/concourse \
     --tsa-host 127.0.0.1 \
     --tsa-public-key /opt/concourse/host_key.pub \
@@ -12,3 +18,5 @@ exec concourse worker \
     --peer-ip 192.168.100.4 \
     --bind-ip 0.0.0.0 \
     --baggageclaim-bind-ip 0.0.0.0
+  EOT
+end script


### PR DESCRIPTION
If a proxy is configured, unfortunately Upstart will not start processes
with /etc/environment variables available. This means that if you have
an external proxy setup (e.g. via vagrant-proxyconf) then things will
not work.

Use the workaround listed at: https://serverfault.com/a/717057

This will explicity set the three parameters:

 --http-proxy
 --https-proxy
 --no-proxy

But if there is no value specified in /etc/environment
this has no ill effects.

The configuration will be passed down to the containers and they will
also utilise the passed through proxy as well.