### PR TITLE
Correct the regex which used to strip away 'export '

### DIFF
--- a/upstart/concourse-worker.conf
+++ b/upstart/concourse-worker.conf
@@ -6,7 +6,7 @@ stop on shutdown
 
 script
   exec /bin/bash << 'EOT'
-  eval $(cat /etc/environment | sed 's/^/export /')
+  eval $(cat /etc/environment | sed 's/^export //')
   concourse worker \
     --http-proxy=$http_proxy \
     --https-proxy=$https_proxy \


### PR DESCRIPTION
/etc/environment is *supposed* to consistent of entries like:

VARIABLE=VALUE

(see: http://man7.org/linux/man-pages/man5/pam_env.conf.5.html)

However for some virtualisation platforms, specifically vagrant
(as a driver of VirtualBox) and its plugin vagrant-proxyconf
do not correctly set things up.

Instead they prefix the lines with 'export VARIABLE=VALUE',
(see: https://github.com/tmatilai/vagrant-proxyconf/issues/159)

Correct the regex to handle this situation -- if vagrant-proxyconf
is fixed, everything will still work as expected.